### PR TITLE
Fix parameter name

### DIFF
--- a/guides/routing.md
+++ b/guides/routing.md
@@ -56,7 +56,7 @@ class Users(UsesState):
 
 class UserProfile(UsesState):
     def build(self):
-        slug = Router.query()['id']
+        slug = Router.query()['slug']
 
         return Text(f"User: {slug}")
 


### PR DESCRIPTION
I was looking at the documentation and it looks like `Router.query()['id']` will fail, as the URL parameter defined above is `:slug`.
I have not tested it (just going through a 1st read of the docs) so maybe I'm wrong